### PR TITLE
Fix bug with missing ln binary

### DIFF
--- a/nspawn-image.nix
+++ b/nspawn-image.nix
@@ -6,10 +6,10 @@
 
   system.build.installBootLoader = pkgs.writeScript "install-sbin-init.sh" ''
     #!${pkgs.runtimeShell}
-    ln -fs "$1/init" /sbin/init
+    ${pkgs.coreutils}/bin/ln -fs "$1/init" /sbin/init
   '';
 
   system.activationScripts.installInitScript = lib.mkForce ''
-    ln -fs $systemConfig/init /sbin/init
+    ${pkgs.coreutils}/bin/ln -fs $systemConfig/init /sbin/init
   '';
 }


### PR DESCRIPTION
In my case, first `nixos-rebuild switch` failed with missing `ln` binary error. This PR switches to coreutils for `ln`.